### PR TITLE
Update requirements.txt

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,7 +3,7 @@ Flask==1.1.1
 werkzeug==0.15.3
 
 # Application server (for both dev and prod)
-gunicorn
+gunicorn==19.9.0
 
 # Testing Code Coverage
 pytest


### PR DESCRIPTION
There seems to be a problem with gunicorn version 20 causing a naming conflict when building a docker image so the requirements.txt file is updated to use the previous version of gunicorn which appears to work fine.